### PR TITLE
Rename OAuth clients

### DIFF
--- a/terragrunt/nonprod/terragrunt.hcl
+++ b/terragrunt/nonprod/terragrunt.hcl
@@ -7,7 +7,7 @@ include "root" {
 }
 
 inputs = {
-  application_display_name       = "Passport Status (nonprod)"
+  application_display_name       = "Passport Status: API (nonprod)"
   application_identifier_uris    = ["api://passport-status-nonprod.esdc-edsc.gc.ca"]
   interop_service_principal_name = "interop-sa-esdc-backends-dev"
 

--- a/terragrunt/prod/terragrunt.hcl
+++ b/terragrunt/prod/terragrunt.hcl
@@ -7,7 +7,7 @@ include "root" {
 }
 
 inputs = {
-  application_display_name       = "Passport Status (prod)"
+  application_display_name       = "Passport Status: API"
   application_identifier_uris    = ["api://passport-status.esdc-edsc.gc.ca"]
   interop_service_principal_name = "interop-sa-esdc-backends"
 


### PR DESCRIPTION
Renaming OAuth clients in preparation for addition of new oauth-proxy clients to protect the frontend. This rename will distinguish the API client from the future oauth-proxy client.